### PR TITLE
Removed incorrect multiplication with PPP for saved window position

### DIFF
--- a/src/gui/app.rs
+++ b/src/gui/app.rs
@@ -62,7 +62,7 @@ impl eframe::App for OverlayProxyApp {
 
         let outer_rect = ctx.input(|i| i.viewport().outer_rect);
         if let Some(outer_rect) = outer_rect {
-            let position = outer_rect.left_top() * ctx.pixels_per_point();
+            let position = outer_rect.left_top();
             self.window_position = Some(position);
         }
 


### PR DESCRIPTION
outer_rect is already in physical pixels, so by multiplying it with pixels per point, the saved window position would be wrong if PPP was something other than 1.