### PR TITLE
1 add api data for matchtournament info

### DIFF
--- a/src/gui/app.rs
+++ b/src/gui/app.rs
@@ -24,6 +24,7 @@ pub struct AppState {
     pub camera_api_id: String,
 
     pub round_manager: RoundManager,
+    pub selected_round: Option<usize>,
 
     pub connected_clients: usize,
     pub spectator_connection: bool,
@@ -36,7 +37,6 @@ pub struct AppState {
 
 pub struct GUIData {
     state: Arc<RwLock<AppState>>,
-    selected_round: Option<usize>,
     window_position: Option<Pos2>,
     first_frame: bool,
 }
@@ -45,7 +45,6 @@ impl GUIData {
     pub(crate) fn new(state: Arc<RwLock<AppState>>) -> Self {
         Self {
             state,
-            selected_round: None,
             window_position: None,
             first_frame: true,
         }
@@ -225,12 +224,12 @@ impl eframe::App for GUIData {
 
                             ui.collapsing("Rounds", |ui| {
                                 if let Some(api) = state.game_state.camera_api.as_ref() {
-                                    let rounds_amount: usize = state.round_manager.get_total_rounds_amount(&api.rounds);
-                                    let rounds: &IndexMap<usize, Round> = &state.round_manager.convert_rounds(&api.rounds);
+                                    let rounds_amount: usize = state.round_manager.get_total_rounds_amount();
+                                    let rounds: &IndexMap<usize, Round> = &state.round_manager.update_rounds();
 
-                                    ui.add(widgets::RoundsPicker::new(rounds, &mut self.selected_round, rounds_amount));
+                                    ui.add(widgets::RoundsPicker::new(rounds, &mut state.selected_round, rounds_amount));
 
-                                    let round_action: RoundAction = if let Some(selected_round) = &self.selected_round {
+                                    let round_action: RoundAction = if let Some(selected_round) = &state.selected_round {
                                         if let Some(round) = rounds.get(selected_round) {
                                             let mut round = round.clone();
                                             let mut changed: bool = false;
@@ -269,7 +268,7 @@ impl eframe::App for GUIData {
                                                 RoundAction::None
                                             }
                                         } else {
-                                            println!("{:?}", rounds.keys().collect::<Vec<_>>());
+                                            println!("{} | {:?}", selected_round, rounds.keys().collect::<Vec<_>>());
                                             RoundAction::Create
                                         }
                                     } else {
@@ -280,12 +279,13 @@ impl eframe::App for GUIData {
                                         RoundAction::Create => {
                                             println!("Created new round");
                                             state.round_manager.add_round(Round::default());
+
                                         }
                                         RoundAction::Override(round_index, round) => {
                                             state.round_manager.add_override(round_index, RoundOverride::Replace(round));
                                         }
                                         RoundAction::Delete(round_index) => {
-                                            self.selected_round = None;
+                                            state.selected_round = None;
                                             state.round_manager.add_override(round_index, RoundOverride::Delete);
                                         }
                                         RoundAction::None => {}

--- a/src/gui/app.rs
+++ b/src/gui/app.rs
@@ -127,143 +127,158 @@ impl eframe::App for OverlayProxyApp {
 
                     ui.add_space(10.0);
 
-                    ui.label("Team Data");
-
-                    ui.scope(|ui| {
-                        ui.style_mut().text_styles.insert(
-                            egui::TextStyle::Button,
-                            egui::FontId::new(10.0, egui::FontFamily::Proportional)
-                        );
-                        ui.style_mut().text_styles.insert(
-                            egui::TextStyle::Body,
-                            egui::FontId::new(10.0, egui::FontFamily::Proportional)
-                        );
-
-                        ui.collapsing("Home Team", |ui| {
+                    ui.collapsing("Match Data", |ui| {
+                        ui.scope(|ui| {
+                            ui.style_mut().text_styles.insert(
+                                egui::TextStyle::Button,
+                                egui::FontId::new(10.0, egui::FontFamily::Proportional)
+                            );
+                            ui.style_mut().text_styles.insert(
+                                egui::TextStyle::Body,
+                                egui::FontId::new(10.0, egui::FontFamily::Proportional)
+                            );
+                            
                             ui.add(widgets::TinyTextEdit::single_line(
-                                "Team Name",
-                                &mut state.game_state.caster_teams.home.name
+                                "Match Host",
+                                &mut state.game_state.match_data.host
                             ).with_desired_width(100.0));
-                            ui.horizontal(|ui| {
-                                if ui.button("Image...").clicked() {
-                                    get_and_upload_logo(Team::Home(state.game_state.caster_teams.home.name.clone()), &mut state);
-                                }
-                                ui.label("Team Logo");
-                            });
-                            if let Ok(texture) = does_image_exist(ctx, &state.game_state.caster_teams.home.logo_url) {
-                                if let Some(image_size) = get_image_size(texture) {
-                                    ui.horizontal(|ui| {
-                                        ui.add(
-                                            egui::Image::new(&state.game_state.caster_teams.home.logo_url)
-                                                .fit_to_exact_size(image_size)
-                                        );
-                                        if ui.button("X").clicked() {
-                                            state.game_state.caster_teams.home.logo_url = String::new();
-                                        }
-                                    });
-                                }
-                            }
-                            ui.label("Current Players");
-                            ui.add(widgets::PlayerList::list(
-                                if let Some(camera_api) = &state.game_state.camera_api {
-                                    camera_api.home.players.keys().cloned().collect()
-                                } else {
-                                    vec![]
-                                }
-                            ));
-                        });
-
-                        ui.collapsing("Away Team", |ui| {
                             ui.add(widgets::TinyTextEdit::single_line(
-                                "Team Name",
-                                &mut state.game_state.caster_teams.away.name
+                                "Match Name",
+                                &mut state.game_state.match_data.name
                             ).with_desired_width(100.0));
-                            ui.horizontal(|ui| {
-                                if ui.button("Image...").clicked() {
-                                    get_and_upload_logo(Team::Away(state.game_state.caster_teams.away.name.clone()), &mut state);
+                            ui.add(widgets::TinyTextEdit::single_line(
+                                "Match Stage",
+                                &mut state.game_state.match_data.stage
+                            ).with_desired_width(100.0));
+
+                            ui.spacing();
+
+                            ui.collapsing("Home Team", |ui| {
+                                ui.add(widgets::TinyTextEdit::single_line(
+                                    "Team Name",
+                                    &mut state.game_state.caster_teams.home.name
+                                ).with_desired_width(100.0));
+                                ui.horizontal(|ui| {
+                                    if ui.button("Image...").clicked() {
+                                        get_and_upload_logo(Team::Home(state.game_state.caster_teams.home.name.clone()), &mut state);
+                                    }
+                                    ui.label("Team Logo");
+                                });
+                                if let Ok(texture) = does_image_exist(ctx, &state.game_state.caster_teams.home.logo_url) {
+                                    if let Some(image_size) = get_image_size(texture) {
+                                        ui.horizontal(|ui| {
+                                            ui.add(
+                                                egui::Image::new(&state.game_state.caster_teams.home.logo_url)
+                                                    .fit_to_exact_size(image_size)
+                                            );
+                                            if ui.button("X").clicked() {
+                                                state.game_state.caster_teams.home.logo_url = String::new();
+                                            }
+                                        });
+                                    }
                                 }
-                                ui.label("Team Logo");
+                                ui.label("Current Players");
+                                ui.add(widgets::PlayerList::list(
+                                    if let Some(camera_api) = &state.game_state.camera_api {
+                                        camera_api.home.players.keys().cloned().collect()
+                                    } else {
+                                        vec![]
+                                    }
+                                ));
                             });
-                            if let Ok(texture) = does_image_exist(ctx, &state.game_state.caster_teams.away.logo_url) {
-                                if let Some(image_size) = get_image_size(texture) {
-                                    ui.horizontal(|ui| {
-                                        ui.add(
-                                            egui::Image::new(&state.game_state.caster_teams.away.logo_url)
-                                                .fit_to_exact_size(image_size)
-                                        );
-                                        if ui.button("X").clicked() {
-                                            state.game_state.caster_teams.away.logo_url = String::new();
-                                        }
-                                    });
+
+                            ui.collapsing("Away Team", |ui| {
+                                ui.add(widgets::TinyTextEdit::single_line(
+                                    "Team Name",
+                                    &mut state.game_state.caster_teams.away.name
+                                ).with_desired_width(100.0));
+                                ui.horizontal(|ui| {
+                                    if ui.button("Image...").clicked() {
+                                        get_and_upload_logo(Team::Away(state.game_state.caster_teams.away.name.clone()), &mut state);
+                                    }
+                                    ui.label("Team Logo");
+                                });
+                                if let Ok(texture) = does_image_exist(ctx, &state.game_state.caster_teams.away.logo_url) {
+                                    if let Some(image_size) = get_image_size(texture) {
+                                        ui.horizontal(|ui| {
+                                            ui.add(
+                                                egui::Image::new(&state.game_state.caster_teams.away.logo_url)
+                                                    .fit_to_exact_size(image_size)
+                                            );
+                                            if ui.button("X").clicked() {
+                                                state.game_state.caster_teams.away.logo_url = String::new();
+                                            }
+                                        });
+                                    }
                                 }
-                            }
-                            ui.label("Current Players");
-                            ui.add(widgets::PlayerList::list(
-                                if let Some(camera_api) = &state.game_state.camera_api {
-                                    camera_api.away.players.keys().cloned().collect()
-                                } else {
-                                    vec![]
-                                }
-                            ));
-                        });
+                                ui.label("Current Players");
+                                ui.add(widgets::PlayerList::list(
+                                    if let Some(camera_api) = &state.game_state.camera_api {
+                                        camera_api.away.players.keys().cloned().collect()
+                                    } else {
+                                        vec![]
+                                    }
+                                ));
+                            });
 
-                        ui.collapsing("Rounds", |ui| {
-                            if let Some(api) = state.game_state.camera_api.as_ref() {
-                                let rounds: &IndexMap<usize, Round> = &api.rounds;
+                            ui.collapsing("Rounds", |ui| {
+                                if let Some(api) = state.game_state.camera_api.as_ref() {
+                                    let rounds: &IndexMap<usize, Round> = &api.rounds;
 
-                                ui.add(widgets::RoundsPicker::new(rounds, &mut self.selected_round));
+                                    ui.add(widgets::RoundsPicker::new(rounds, &mut self.selected_round));
 
-                                let round_action: RoundAction = if let Some(round) = rounds.get(&self.selected_round) {
-                                    let mut round = round.clone();
-                                    let mut changed: bool = false;
-                                    let mut should_delete: bool = false;
+                                    let round_action: RoundAction = if let Some(round) = rounds.get(&self.selected_round) {
+                                        let mut round = round.clone();
+                                        let mut changed: bool = false;
+                                        let mut should_delete: bool = false;
 
-                                    ui.separator();
-                                    ui.horizontal(|ui| {
-                                        ui.vertical(|ui| {
-                                            ui.label("Home");
-                                            if ui.add(egui::DragValue::new(&mut round.home).suffix(" score")).changed() {
-                                                changed = true;
+                                        ui.separator();
+                                        ui.horizontal(|ui| {
+                                            ui.vertical(|ui| {
+                                                ui.label("Home");
+                                                if ui.add(egui::DragValue::new(&mut round.home).suffix(" score")).changed() {
+                                                    changed = true;
+                                                }
+                                            });
+
+                                            ui.add_space(20.0);
+
+                                            ui.vertical(|ui| {
+                                                ui.label("Away");
+                                                if ui.add(egui::DragValue::new(&mut round.away).suffix(" score")).changed() {
+                                                    changed = true;
+                                                }
+                                            });
+
+                                            ui.add_space(20.0);
+
+                                            if ui.button("Delete").clicked() {
+                                                should_delete = true;
                                             }
                                         });
 
-                                        ui.add_space(20.0);
-
-                                        ui.vertical(|ui| {
-                                            ui.label("Away");
-                                            if ui.add(egui::DragValue::new(&mut round.away).suffix(" score")).changed() {
-                                                changed = true;
-                                            }
-                                        });
-
-                                        ui.add_space(20.0);
-
-                                        if ui.button("Delete").clicked() {
-                                            should_delete = true;
+                                        if should_delete {
+                                            RoundAction::Delete
+                                        } else if changed {
+                                            RoundAction::Override(Round {home: round.home, away: round.away})
+                                        } else {
+                                            RoundAction::None
                                         }
-                                    });
-
-                                    if should_delete {
-                                        RoundAction::Delete
-                                    } else if changed {
-                                        RoundAction::Override(Round {home: round.home, away: round.away})
                                     } else {
                                         RoundAction::None
-                                    }
-                                } else {
-                                    RoundAction::None
-                                };
+                                    };
 
-                                match round_action {
-                                    RoundAction::Override(round) => {
-                                        state.round_manager.add_override(self.selected_round, RoundOverride::Replace(round));
+                                    match round_action {
+                                        RoundAction::Override(round) => {
+                                            state.round_manager.add_override(self.selected_round, RoundOverride::Replace(round));
+                                        }
+                                        RoundAction::Delete => {
+                                            state.round_manager.add_override(self.selected_round, RoundOverride::Delete);
+                                        }
+                                        RoundAction::None => {}
                                     }
-                                    RoundAction::Delete => {
-                                        state.round_manager.add_override(self.selected_round, RoundOverride::Delete);
-                                    }
-                                    RoundAction::None => {}
                                 }
-                            }
+                            });
                         });
                     });
             });

--- a/src/gui/app.rs
+++ b/src/gui/app.rs
@@ -12,6 +12,7 @@ use crate::managers::rounds::{RoundManager, RoundOverride};
 use crate::ws::state::{GameState, Round};
 
 enum RoundAction {
+    Create,
     Override(Round),
     Delete,
     None
@@ -35,7 +36,7 @@ pub struct AppState {
 
 pub struct OverlayProxyApp {
     state: Arc<RwLock<AppState>>,
-    selected_round: usize,
+    selected_round: i32,
     window_position: Option<Pos2>,
     first_frame: bool,
 }
@@ -44,7 +45,7 @@ impl OverlayProxyApp {
     pub(crate) fn new(state: Arc<RwLock<AppState>>) -> Self {
         Self {
             state,
-            selected_round: 1,
+            selected_round: -1,
             window_position: None,
             first_frame: true,
         }
@@ -137,7 +138,7 @@ impl eframe::App for OverlayProxyApp {
                                 egui::TextStyle::Body,
                                 egui::FontId::new(10.0, egui::FontFamily::Proportional)
                             );
-                            
+
                             ui.add(widgets::TinyTextEdit::single_line(
                                 "Match Host",
                                 &mut state.game_state.match_data.host
@@ -223,11 +224,11 @@ impl eframe::App for OverlayProxyApp {
 
                             ui.collapsing("Rounds", |ui| {
                                 if let Some(api) = state.game_state.camera_api.as_ref() {
-                                    let rounds: &IndexMap<usize, Round> = &api.rounds;
+                                    let rounds: &IndexMap<usize, Round> = &state.round_manager.convert_rounds(&api.rounds);
 
-                                    ui.add(widgets::RoundsPicker::new(rounds, &mut self.selected_round));
+                                    ui.add(widgets::RoundsPicker::new(rounds, &mut (self.selected_round as usize)));
 
-                                    let round_action: RoundAction = if let Some(round) = rounds.get(&self.selected_round) {
+                                    let round_action: RoundAction = if let Some(round) = rounds.get(&(self.selected_round as usize)) {
                                         let mut round = round.clone();
                                         let mut changed: bool = false;
                                         let mut should_delete: bool = false;
@@ -264,16 +265,22 @@ impl eframe::App for OverlayProxyApp {
                                         } else {
                                             RoundAction::None
                                         }
-                                    } else {
+                                    } else if self.selected_round == -1 {
                                         RoundAction::None
+                                    } else {
+                                        RoundAction::Create
                                     };
 
                                     match round_action {
+                                        RoundAction::Create => {
+                                            println!("Created new round");
+                                            state.round_manager.add_round(Round::default());
+                                        }
                                         RoundAction::Override(round) => {
-                                            state.round_manager.add_override(self.selected_round, RoundOverride::Replace(round));
+                                            state.round_manager.add_override(self.selected_round as usize, RoundOverride::Replace(round));
                                         }
                                         RoundAction::Delete => {
-                                            state.round_manager.add_override(self.selected_round, RoundOverride::Delete);
+                                            state.round_manager.add_override(self.selected_round as usize, RoundOverride::Delete);
                                         }
                                         RoundAction::None => {}
                                     }

--- a/src/gui/app.rs
+++ b/src/gui/app.rs
@@ -34,14 +34,14 @@ pub struct AppState {
     pub broadcast_tx: tokio::sync::broadcast::Sender<GameState>,
 }
 
-pub struct OverlayProxyApp {
+pub struct GUIData {
     state: Arc<RwLock<AppState>>,
     selected_round: Option<usize>,
     window_position: Option<Pos2>,
     first_frame: bool,
 }
 
-impl OverlayProxyApp {
+impl GUIData {
     pub(crate) fn new(state: Arc<RwLock<AppState>>) -> Self {
         Self {
             state,
@@ -52,7 +52,7 @@ impl OverlayProxyApp {
     }
 }
 
-impl eframe::App for OverlayProxyApp {
+impl eframe::App for GUIData {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
         if self.first_frame {
             ctx.set_pixels_per_point(1.5);

--- a/src/gui/app.rs
+++ b/src/gui/app.rs
@@ -13,8 +13,8 @@ use crate::ws::state::{GameState, Round};
 
 enum RoundAction {
     Create,
-    Override(Round),
-    Delete,
+    Override(usize, Round),
+    Delete(usize),
     None
 }
 
@@ -36,7 +36,7 @@ pub struct AppState {
 
 pub struct OverlayProxyApp {
     state: Arc<RwLock<AppState>>,
-    selected_round: i32,
+    selected_round: Option<usize>,
     window_position: Option<Pos2>,
     first_frame: bool,
 }
@@ -45,7 +45,7 @@ impl OverlayProxyApp {
     pub(crate) fn new(state: Arc<RwLock<AppState>>) -> Self {
         Self {
             state,
-            selected_round: -1,
+            selected_round: None,
             window_position: None,
             first_frame: true,
         }
@@ -224,51 +224,55 @@ impl eframe::App for OverlayProxyApp {
 
                             ui.collapsing("Rounds", |ui| {
                                 if let Some(api) = state.game_state.camera_api.as_ref() {
+                                    let rounds_amount: usize = state.round_manager.get_total_rounds_amount(&api.rounds);
                                     let rounds: &IndexMap<usize, Round> = &state.round_manager.convert_rounds(&api.rounds);
 
-                                    ui.add(widgets::RoundsPicker::new(rounds, &mut (self.selected_round as usize)));
+                                    ui.add(widgets::RoundsPicker::new(rounds, &mut self.selected_round, rounds_amount));
 
-                                    let round_action: RoundAction = if let Some(round) = rounds.get(&(self.selected_round as usize)) {
-                                        let mut round = round.clone();
-                                        let mut changed: bool = false;
-                                        let mut should_delete: bool = false;
+                                    let round_action: RoundAction = if let Some(selected_round) = &self.selected_round {
+                                        if let Some(round) = rounds.get(selected_round) {
+                                            let mut round = round.clone();
+                                            let mut changed: bool = false;
+                                            let mut should_delete: bool = false;
 
-                                        ui.separator();
-                                        ui.horizontal(|ui| {
-                                            ui.vertical(|ui| {
-                                                ui.label("Home");
-                                                if ui.add(egui::DragValue::new(&mut round.home).suffix(" score")).changed() {
-                                                    changed = true;
+                                            ui.separator();
+                                            ui.horizontal(|ui| {
+                                                ui.vertical(|ui| {
+                                                    ui.label("Home");
+                                                    if ui.add(egui::DragValue::new(&mut round.home).suffix(" score")).changed() {
+                                                        changed = true;
+                                                    }
+                                                });
+
+                                                ui.add_space(20.0);
+
+                                                ui.vertical(|ui| {
+                                                    ui.label("Away");
+                                                    if ui.add(egui::DragValue::new(&mut round.away).suffix(" score")).changed() {
+                                                        changed = true;
+                                                    }
+                                                });
+
+                                                ui.add_space(20.0);
+
+                                                if ui.button("Delete").clicked() {
+                                                    should_delete = true;
                                                 }
                                             });
 
-                                            ui.add_space(20.0);
-
-                                            ui.vertical(|ui| {
-                                                ui.label("Away");
-                                                if ui.add(egui::DragValue::new(&mut round.away).suffix(" score")).changed() {
-                                                    changed = true;
-                                                }
-                                            });
-
-                                            ui.add_space(20.0);
-
-                                            if ui.button("Delete").clicked() {
-                                                should_delete = true;
+                                            if should_delete {
+                                                RoundAction::Delete(*selected_round)
+                                            } else if changed {
+                                                RoundAction::Override(*selected_round, Round {home: round.home, away: round.away})
+                                            } else {
+                                                RoundAction::None
                                             }
-                                        });
-
-                                        if should_delete {
-                                            RoundAction::Delete
-                                        } else if changed {
-                                            RoundAction::Override(Round {home: round.home, away: round.away})
                                         } else {
-                                            RoundAction::None
+                                            println!("{:?}", rounds.keys().collect::<Vec<_>>());
+                                            RoundAction::Create
                                         }
-                                    } else if self.selected_round == -1 {
-                                        RoundAction::None
                                     } else {
-                                        RoundAction::Create
+                                        RoundAction::None
                                     };
 
                                     match round_action {
@@ -276,11 +280,12 @@ impl eframe::App for OverlayProxyApp {
                                             println!("Created new round");
                                             state.round_manager.add_round(Round::default());
                                         }
-                                        RoundAction::Override(round) => {
-                                            state.round_manager.add_override(self.selected_round as usize, RoundOverride::Replace(round));
+                                        RoundAction::Override(round_index, round) => {
+                                            state.round_manager.add_override(round_index, RoundOverride::Replace(round));
                                         }
-                                        RoundAction::Delete => {
-                                            state.round_manager.add_override(self.selected_round as usize, RoundOverride::Delete);
+                                        RoundAction::Delete(round_index) => {
+                                            self.selected_round = None;
+                                            state.round_manager.add_override(round_index, RoundOverride::Delete);
                                         }
                                         RoundAction::None => {}
                                     }

--- a/src/gui/app.rs
+++ b/src/gui/app.rs
@@ -63,7 +63,8 @@ impl eframe::App for OverlayProxyApp {
 
         let outer_rect = ctx.input(|i| i.viewport().outer_rect);
         if let Some(outer_rect) = outer_rect {
-            let position = outer_rect.left_top();
+            let native_ppp = ctx.input(|i| i.viewport().native_pixels_per_point.unwrap_or(1.0));
+            let position = outer_rect.left_top() * (ctx.pixels_per_point() / native_ppp);
             self.window_position = Some(position);
         }
 

--- a/src/gui/widgets.rs
+++ b/src/gui/widgets.rs
@@ -171,6 +171,13 @@ impl<'v> egui::Widget for RoundsPicker<'v> {
                             *self.selected_value = *k
                         }
                     }
+                    if ui.add_sized(
+                        [ui.available_width(), 0.0],
+                        egui::Button::new("+")
+                    ).clicked() {
+                        *self.selected_value = self.rounds.keys().max().map_or(0, |k| k + 1);
+                        println!("{}", self.selected_value);
+                    }
                 });
             }).response
     }

--- a/src/gui/widgets.rs
+++ b/src/gui/widgets.rs
@@ -140,14 +140,16 @@ impl<'v> egui::Widget for PlayerList {
 
 pub struct RoundsPicker<'v> {
     rounds: &'v IndexMap<usize, Round>,
-    selected_value: &'v mut usize
+    selected_value: &'v mut Option<usize>,
+    new_round_index: usize,
 }
 
 impl<'v> RoundsPicker<'v> {
-    pub fn new(rounds: &'v IndexMap<usize, Round>, selected_value: &'v mut usize) -> Self {
+    pub fn new(rounds: &'v IndexMap<usize, Round>, selected_value: &'v mut Option<usize>, new_round_index: usize) -> Self {
         Self {
             rounds,
-            selected_value
+            selected_value,
+            new_round_index,
         }
     }
 }
@@ -166,17 +168,17 @@ impl<'v> egui::Widget for RoundsPicker<'v> {
 
                         if ui.add_sized(
                             [ui.available_width(), 0.0],
-                            egui::Button::selectable(self.selected_value == k, format!("round {}", i+1))
+                            egui::Button::selectable(self.selected_value.is_some() && self.selected_value.unwrap() == *k, format!("round {}", i+1))
                         ).clicked() {
-                            *self.selected_value = *k
+                            *self.selected_value = Some(*k)
                         }
                     }
                     if ui.add_sized(
                         [ui.available_width(), 0.0],
                         egui::Button::new("+")
                     ).clicked() {
-                        *self.selected_value = self.rounds.keys().max().map_or(0, |k| k + 1);
-                        println!("{}", self.selected_value);
+                        *self.selected_value = Some(self.new_round_index);
+                        println!("{}", self.new_round_index);
                     }
                 });
             }).response

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ use crate::ws::{server, api};
 use crate::gui::app::{OverlayProxyApp, AppState};
 use crate::managers::appdata::AppData;
 use crate::managers::rounds::RoundManager;
-use crate::ws::state::{CameraApi, CasterTeams, GameState, MatchData};
+use crate::ws::state::{CameraApi, CasterTeams, GameState, GamemodeData, MatchData};
 
 fn main() -> eframe::Result {
     let app_data = AppData::get_or_init();
@@ -26,7 +26,16 @@ fn main() -> eframe::Result {
         game_state: GameState {
             game_data: None,
             gamemodes: vec![],
-            selected_gamemode: None,
+            selected_gamemode: {
+                #[cfg(debug_assertions)]
+                {
+                    Some(GamemodeData::default())
+                }
+                #[cfg(not(debug_assertions))]
+                {
+                    None
+                }
+            },
             cameras: vec![],
             camera_api: {
                 #[cfg(debug_assertions)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ use crate::ws::{server, api};
 use crate::gui::app::{OverlayProxyApp, AppState};
 use crate::managers::appdata::AppData;
 use crate::managers::rounds::RoundManager;
-use crate::ws::state::{CasterTeams, GameState};
+use crate::ws::state::{CasterTeams, GameState, MatchData};
 
 fn main() -> eframe::Result {
     let app_data = AppData::get_or_init();
@@ -27,6 +27,7 @@ fn main() -> eframe::Result {
             cameras: vec![],
             camera_api: None,
             caster_teams: CasterTeams::default(),
+            match_data: MatchData::default(),
         },
         subscribed_gamemode_slot_id: String::new(),
         camera_api_id: app_data.camera_api_id,
@@ -63,7 +64,7 @@ fn main() -> eframe::Result {
     });
 
     let mut viewport = egui::ViewportBuilder::default()
-        .with_inner_size([320.0, 780.0])
+        .with_inner_size([340.0, 780.0])
         .with_resizable(false)
         .with_maximize_button(false);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ use crate::ws::{server, api};
 use crate::gui::app::{OverlayProxyApp, AppState};
 use crate::managers::appdata::AppData;
 use crate::managers::rounds::RoundManager;
-use crate::ws::state::{CasterTeams, GameState, MatchData};
+use crate::ws::state::{CameraApi, CasterTeams, GameState, MatchData};
 
 fn main() -> eframe::Result {
     let app_data = AppData::get_or_init();
@@ -25,7 +25,16 @@ fn main() -> eframe::Result {
             gamemodes: vec![],
             selected_gamemode: None,
             cameras: vec![],
-            camera_api: None,
+            camera_api: {
+                #[cfg(debug_assertions)]
+                {
+                    Some(CameraApi::default())
+                }
+                #[cfg(not(debug_assertions))]
+                {
+                    None
+                }
+            },
             caster_teams: CasterTeams::default(),
             match_data: MatchData::default(),
         },

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ use tokio::sync::RwLock;
 use eframe::egui;
 use egui_extras::install_image_loaders;
 use crate::ws::{server, api};
-use crate::gui::app::{OverlayProxyApp, AppState};
+use crate::gui::app::{GUIData, AppState};
 use crate::managers::appdata::AppData;
 use crate::managers::rounds::RoundManager;
 use crate::ws::state::{CameraApi, CasterTeams, GameState, GamemodeData, MatchData};
@@ -106,7 +106,7 @@ fn main() -> eframe::Result {
                 style.spacing.item_spacing.x = 2.0;
             });
             install_image_loaders(&cc.egui_ctx);
-            Ok(Box::new(OverlayProxyApp::new(state)))
+            Ok(Box::new(GUIData::new(state)))
         }),
     )
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,6 +54,7 @@ fn main() -> eframe::Result {
         camera_api_id: app_data.camera_api_id,
         
         round_manager: RoundManager::new(),
+        selected_round: None,
         
         connected_clients: 0,
         spectator_connection: false,

--- a/src/managers/rounds.rs
+++ b/src/managers/rounds.rs
@@ -60,13 +60,13 @@ impl RoundManager {
         extended
     }
 
-    pub fn save_rounds(&mut self, rounds: &IndexMap<usize, Round>) {
+    pub fn save_pre_converted_rounds(&mut self, rounds: &IndexMap<usize, Round>) {
         self.pre_converted_rounds = rounds.clone();
     }
 
-    pub fn convert_rounds(&self, rounds: &IndexMap<usize, Round>) -> IndexMap<usize, Round> {
+    pub fn convert_rounds(&mut self, rounds: &IndexMap<usize, Round>) -> IndexMap<usize, Round> {
         let mut converted_rounds: IndexMap<usize, Round> = IndexMap::new();
-
+        
         let all_rounds: IndexMap<usize, Round> = self.extend_archived_rounds(rounds);
 
         for (i, round) in all_rounds.iter() {
@@ -87,8 +87,12 @@ impl RoundManager {
         converted_rounds
     }
 
-    pub fn get_total_rounds_amount(&self, rounds: &IndexMap<usize, Round>) -> usize {
-        self.archived_rounds.iter().count() + rounds.iter().count()
+    pub fn update_rounds(&mut self) -> IndexMap<usize, Round> {
+        self.convert_rounds(&self.pre_converted_rounds.clone())
+    }
+
+    pub fn get_total_rounds_amount(&self) -> usize {
+        self.archived_rounds.iter().count() + self.pre_converted_rounds.iter().count()
     }
 
     pub fn has_wiped(&self, new_rounds: &IndexMap<usize, Round>) -> bool {

--- a/src/managers/rounds.rs
+++ b/src/managers/rounds.rs
@@ -87,6 +87,10 @@ impl RoundManager {
         converted_rounds
     }
 
+    pub fn get_total_rounds_amount(&self, rounds: &IndexMap<usize, Round>) -> usize {
+        self.archived_rounds.iter().count() + rounds.iter().count()
+    }
+
     pub fn has_wiped(&self, new_rounds: &IndexMap<usize, Round>) -> bool {
         new_rounds.len() < self.pre_converted_rounds.len()
     }

--- a/src/managers/rounds.rs
+++ b/src/managers/rounds.rs
@@ -25,6 +25,11 @@ impl RoundManager {
         }
     }
 
+    pub fn add_round(&mut self, round: Round) {
+        let index = self.archived_rounds.len();
+        self.archived_rounds.insert(index, round);
+    }
+
     pub fn add_override(&mut self, index: usize, round_override: RoundOverride) {
         self.overrides.insert(index, round_override);
     }
@@ -55,10 +60,12 @@ impl RoundManager {
         extended
     }
 
-    pub fn convert_rounds(&mut self, rounds: &IndexMap<usize, Round>) -> IndexMap<usize, Round> {
-        let mut converted_rounds: IndexMap<usize, Round> = IndexMap::new();
-
+    pub fn save_rounds(&mut self, rounds: &IndexMap<usize, Round>) {
         self.pre_converted_rounds = rounds.clone();
+    }
+
+    pub fn convert_rounds(&self, rounds: &IndexMap<usize, Round>) -> IndexMap<usize, Round> {
+        let mut converted_rounds: IndexMap<usize, Round> = IndexMap::new();
 
         let all_rounds: IndexMap<usize, Round> = self.extend_archived_rounds(rounds);
 

--- a/src/ws/api.rs
+++ b/src/ws/api.rs
@@ -203,6 +203,7 @@ async fn handle_subscribed_config(cameras_response: &CamerasResponse, client: &C
                     }
                 }
 
+                s.round_manager.save_rounds(&camera_config.api.rounds);
                 camera_config.api.rounds = s.round_manager.convert_rounds(&camera_config.api.rounds);
 
                 s.game_state.camera_api = Some(camera_config.api);

--- a/src/ws/api.rs
+++ b/src/ws/api.rs
@@ -60,7 +60,16 @@ pub async fn poll_game_data(state: Arc<RwLock<AppState>>) {
 
         {
             let s = state.read().await;
-            let _ = s.broadcast_tx.send(s.game_state.clone());
+            let mut game_state = s.game_state.clone();
+
+            // On linux polling does not work, therefore we need to convert rounds on sending
+            // instead of on recieveing
+            #[cfg(not(target_os = "windows"))]
+            if let Some(api) = &mut game_state.camera_api {
+                api.rounds = s.round_manager.convert_rounds(&api.rounds);
+            }
+
+            let _ = s.broadcast_tx.send(game_state);
         }
 
         tokio::time::sleep(tokio::time::Duration::from_millis(interval)).await;

--- a/src/ws/api.rs
+++ b/src/ws/api.rs
@@ -213,10 +213,11 @@ async fn handle_subscribed_config(cameras_response: &CamerasResponse, client: &C
                         println!("winner, removing overrides");
                         s.round_manager.clear_archives();
                         s.round_manager.clear_overrides();
+                        s.selected_round = None;
                     }
                 }
-
-                s.round_manager.save_rounds(&camera_config.api.rounds);
+                
+                s.round_manager.save_pre_converted_rounds(&camera_config.api.rounds);
                 camera_config.api.rounds = s.round_manager.convert_rounds(&camera_config.api.rounds);
 
                 s.game_state.camera_api = Some(camera_config.api);

--- a/src/ws/api.rs
+++ b/src/ws/api.rs
@@ -82,6 +82,7 @@ async fn handle_game_data(client: &Client, state: &Arc<RwLock<AppState>>) -> boo
             true
         }
         Err(e) => {
+            #[cfg(target_os = "windows")]
             eprintln!("Failed to poll spectator API: {}", e);
             false
         }
@@ -103,6 +104,7 @@ async fn handle_gamemodes(client: &Client, state: &Arc<RwLock<AppState>>) -> boo
             true
         }
         Err(e) => {
+            #[cfg(target_os = "windows")]
             eprintln!("Failed to poll spectator API: {}", e);
             false
         }
@@ -134,6 +136,7 @@ async fn handle_subscribed_gamemode(response_data: &GamemodesResponse, client: &
             true
         }
         Err(e) => {
+            #[cfg(target_os = "windows")]
             eprintln!("Failed to get gamemode: {}: {}", subscribed_slot_id, e);
             false
         }
@@ -155,6 +158,7 @@ async fn handle_cameras(client: &Client, state: &Arc<RwLock<AppState>>) -> bool 
             true
         }
         Err(e) => {
+            #[cfg(target_os = "windows")]
             eprintln!("Failed to get cameras: {}", e);
             false
         }
@@ -211,6 +215,7 @@ async fn handle_subscribed_config(cameras_response: &CamerasResponse, client: &C
             true
         }
         Err(e) => {
+            #[cfg(target_os = "windows")]
             eprintln!("Failed to get subscribed camera: {}", e);
             false
         }

--- a/src/ws/state.rs
+++ b/src/ws/state.rs
@@ -107,7 +107,7 @@ impl GamemodeTeam {
             team_color
         }
     }
-    
+
     pub fn home_team() -> Self {
         Self::default_team(TeamColor {
             primary: Color {

--- a/src/ws/state.rs
+++ b/src/ws/state.rs
@@ -133,16 +133,45 @@ pub struct ShotInfo {
     pub shot_distance_meters: f64,
 }
 
+impl Default for ShotInfo {
+    fn default() -> Self {
+        Self {
+            shooter: String::new(),
+            assister: String::new(),
+            team: -1,
+            shot_speed: 0.0,
+            shot_distance_meters: 0.0
+        }
+    }
+}
+
 #[derive(Clone, Copy, Deserialize, Serialize)]
 pub struct Round {
     pub home: i32,
     pub away: i32,
 }
 
+impl Default for Round {
+    fn default() -> Self {
+        Self {
+            home: 0,
+            away: 0
+        }
+    }
+}
+
 #[derive(Clone, Deserialize, Serialize)]
 pub struct OverlayTeam {
     #[serde(deserialize_with = "deserialize_players")]
     pub players: IndexMap<String, Stats>,
+}
+
+impl Default for OverlayTeam {
+    fn default() -> Self {
+        Self {
+            players: IndexMap::new()
+        }
+    }
 }
 
 fn deserialize_players<'de, D>(deserializer: D) -> Result<IndexMap<String, Stats>, D::Error>
@@ -185,6 +214,23 @@ pub struct CameraApi {
     pub best_of: i32,
     #[serde(rename = "matchLengthSeconds")]
     pub match_length_seconds: i32,
+}
+
+impl Default for CameraApi {
+    fn default() -> Self {
+        Self {
+            gamemode_id: String::new(),
+            home: OverlayTeam::default(),
+            away: OverlayTeam::default(),
+            rounds: IndexMap::new(),
+            followed_player: String::new(),
+            last_shot_info: ShotInfo::default(),
+            is_grace_period: false,
+            is_overtime: false,
+            best_of: 3,
+            match_length_seconds: 300
+        }
+    }
 }
 
 fn deserialize_rounds<'de, D>(deserializer: D) -> Result<IndexMap<usize, Round>, D::Error>

--- a/src/ws/state.rs
+++ b/src/ws/state.rs
@@ -235,6 +235,23 @@ impl Default for CasterTeams {
 }
 
 #[derive(Clone, Deserialize, Serialize)]
+pub struct MatchData {
+    pub host: String,
+    pub name: String,
+    pub stage: String,
+}
+
+impl Default for MatchData {
+    fn default() -> Self {
+        Self {
+            host: String::default(),
+            name: String::default(),
+            stage: String::default()
+        }
+    }
+}
+
+#[derive(Clone, Deserialize, Serialize)]
 pub struct GameState {
     #[serde(rename = "gameData")]
     pub game_data: Option<GameData>,
@@ -246,4 +263,6 @@ pub struct GameState {
     pub camera_api: Option<CameraApi>,
     #[serde(rename = "casterTeams")]
     pub caster_teams: CasterTeams,
+    #[serde(rename = "matchData")]
+    pub match_data: MatchData,
 }

--- a/src/ws/state.rs
+++ b/src/ws/state.rs
@@ -103,7 +103,7 @@ impl GamemodeTeam {
         Self {
             score: 0,
             rounds_won: 0,
-            players: vec![SimplePlayer {player_id: 1, player_name: String::from("Player1"), position: Vec3 {x: 0.0, y: 0.0, z: 0.0}}],
+            players: vec![],
             team_color
         }
     }
@@ -181,6 +181,16 @@ pub struct Stats {
     pub assists: i32,
 }
 
+impl Default for Stats {
+    fn default() -> Self {
+        Self {
+            goals: 0,
+            saves: 0,
+            assists: 0
+        }
+    }
+}
+
 #[derive(Clone, Deserialize, Serialize)]
 pub struct ShotInfo {
     pub shooter: String,
@@ -225,10 +235,27 @@ pub struct OverlayTeam {
     pub players: IndexMap<String, Stats>,
 }
 
-impl Default for OverlayTeam {
-    fn default() -> Self {
+
+impl OverlayTeam {
+    pub fn home_team() -> Self {
         Self {
-            players: IndexMap::new()
+            players: IndexMap::from([
+                ("Player1".to_string(), Stats::default()),
+                ("Player2".to_string(), Stats::default()),
+                ("Player3".to_string(), Stats::default()),
+                ("Player4".to_string(), Stats::default()),
+            ]),
+        }
+    }
+
+    pub fn away_team() -> Self {
+        Self {
+            players: IndexMap::from([
+                ("PlayerWithLongNameAsh".to_string(), Stats::default()),
+                ("Player6".to_string(), Stats::default()),
+                ("Player7".to_string(), Stats::default()),
+                ("Player8".to_string(), Stats::default()),
+            ]),
         }
     }
 }
@@ -279,8 +306,8 @@ impl Default for CameraApi {
     fn default() -> Self {
         Self {
             gamemode_id: String::new(),
-            home: OverlayTeam::default(),
-            away: OverlayTeam::default(),
+            home: OverlayTeam::home_team(),
+            away: OverlayTeam::away_team(),
             rounds: IndexMap::new(),
             followed_player: String::new(),
             last_shot_info: ShotInfo::default(),

--- a/src/ws/state.rs
+++ b/src/ws/state.rs
@@ -98,6 +98,51 @@ pub struct GamemodeTeam {
     pub team_color: TeamColor,
 }
 
+impl GamemodeTeam {
+    fn default_team(team_color: TeamColor) -> Self {
+        Self {
+            score: 0,
+            rounds_won: 0,
+            players: vec![SimplePlayer {player_id: 1, player_name: String::from("Player1"), position: Vec3 {x: 0.0, y: 0.0, z: 0.0}}],
+            team_color
+        }
+    }
+    
+    pub fn home_team() -> Self {
+        Self::default_team(TeamColor {
+            primary: Color {
+                r: 223,
+                g: 45,
+                b: 82,
+                a: 255
+            },
+            secondary: Color {
+                r: 223,
+                g: 45,
+                b: 82,
+                a: 255
+            }
+        })
+    }
+
+    pub fn away_team() -> Self {
+        Self::default_team(TeamColor {
+            primary: Color {
+                r: 9,
+                g: 114,
+                b: 213,
+                a: 255
+            },
+            secondary: Color {
+                r: 9,
+                g: 114,
+                b: 213,
+                a: 255
+            }
+        })
+    }
+}
+
 #[derive(Clone, Deserialize, Serialize)]
 pub struct GamemodeData {
     #[serde(rename = "slotId")]
@@ -113,6 +158,20 @@ pub struct GamemodeData {
     #[serde(rename = "useBestOf")]
     pub use_best_of: bool,
     pub teams: Vec<GamemodeTeam>,
+}
+
+impl Default for GamemodeData {
+    fn default() -> Self {
+        Self {
+            slot_id: String::from("gamma01"),
+            time_seconds: 300.0,
+            secondary_time_seconds: 0.0,
+            is_game_running: false,
+            total_rounds: 3,
+            use_best_of: true,
+            teams: vec![GamemodeTeam::home_team(), GamemodeTeam::away_team()]
+        }
+    }
 }
 
 #[derive(Clone, Deserialize, Serialize)]


### PR DESCRIPTION
There are a lot of changes to the rounds overlay here as well, which in turn introduces a way to add played rounds from the caster bridge.

These changes were made so that i could work on the feature from linux.