### PR TITLE
Revert "removed unused crate (#10)"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2024"
 [dependencies]
 eframe = "0.34.3"
 egui_extras = { version = "0.34.3", features = ["image", "http"] }
+image = { version = "0.25.9", features = ["png", "jpeg"] }
 
 tokio = { version = "1.49.0", features = ["full"]}
 tokio-tungstenite = "0.28.0"


### PR DESCRIPTION
This reverts commit a4531e0e03be943a63e0ef4f80c6da3c8a1bdc09.

The image crate is used to ensure images with certain file extensions are able to be rendered in the GUI. Removing it was a complete mistake